### PR TITLE
[B002] 새로운 편지 생성 기능

### DIFF
--- a/src/main/java/com/snailmail/back/controller/LetterController.java
+++ b/src/main/java/com/snailmail/back/controller/LetterController.java
@@ -1,0 +1,29 @@
+package com.snailmail.back.controller;
+
+import com.snailmail.back.dto.request.LetterCreateRequest;
+import com.snailmail.back.dto.response.ApiResponse;
+import com.snailmail.back.dto.response.LetterResponse;
+import com.snailmail.back.service.LetterService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/letters")
+@RequiredArgsConstructor
+public class LetterController {
+
+    private final LetterService letterService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<LetterResponse> createLetter(@RequestBody LetterCreateRequest request) {
+        LetterResponse response = letterService.createLetter(request);
+
+        return ApiResponse.success(response);
+    }
+}

--- a/src/main/java/com/snailmail/back/domain/BaseEntity.java
+++ b/src/main/java/com/snailmail/back/domain/BaseEntity.java
@@ -1,0 +1,24 @@
+package com.snailmail.back.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    protected LocalDateTime createdDatetime;
+
+    @LastModifiedDate
+    @Column(updatable = false)
+    protected LocalDateTime updatedDatetime;
+}

--- a/src/main/java/com/snailmail/back/domain/Letter.java
+++ b/src/main/java/com/snailmail/back/domain/Letter.java
@@ -1,5 +1,6 @@
 package com.snailmail.back.domain;
 
+import com.snailmail.back.utils.StringUtil;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -10,6 +11,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
+import java.text.MessageFormat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
@@ -31,7 +33,7 @@ public class Letter {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
 
-    @Column(nullable = false, unique = true, length = 100)
+    @Column(unique = true, length = 100)
     private String reservationKey;
 
     @Column(nullable = false, length = 15)
@@ -78,5 +80,13 @@ public class Letter {
         this.content = content;
         this.password = password;
         this.letterStatus = letterStatus;
+    }
+
+    public void registerReservationKey() {
+        String prefix = StringUtil.localDateToString(LocalDate.now());
+        String infix = StringUtil.fillZero(id);
+        String suffix = StringUtil.getRandomUppercaseString();
+
+        this.reservationKey = MessageFormat.format("{0}{1}{2}", prefix, infix, suffix);
     }
 }

--- a/src/main/java/com/snailmail/back/domain/Letter.java
+++ b/src/main/java/com/snailmail/back/domain/Letter.java
@@ -3,7 +3,6 @@ package com.snailmail.back.domain;
 import com.snailmail.back.utils.StringUtil;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
@@ -13,21 +12,16 @@ import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
 import java.text.MessageFormat;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Table(name = "letters")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@EntityListeners(AuditingEntityListener.class)
-public class Letter {
+public class Letter extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
@@ -59,13 +53,6 @@ public class Letter {
 
     @Enumerated(value = EnumType.STRING)
     private LetterStatus letterStatus;
-
-    @CreatedDate
-    @Column(updatable = false)
-    private LocalDateTime createdDatetime;
-
-    @LastModifiedDate
-    private LocalDateTime updatedDatetime;
 
     @Builder
     public Letter(String reservationKey, String senderName, String recipientName,

--- a/src/main/java/com/snailmail/back/domain/Letter.java
+++ b/src/main/java/com/snailmail/back/domain/Letter.java
@@ -59,8 +59,7 @@ public class Letter {
     @Builder
     public Letter(String reservationKey, String senderName, String recipientName,
             String recipientEmail, LocalDate scheduledDate, Integer duration,
-            String content, String password, LetterStatus letterStatus, LocalDateTime createdDatetime,
-            LocalDateTime updatedDatetime) {
+            String content, String password, LetterStatus letterStatus) {
         this.reservationKey = reservationKey;
         this.senderName = senderName;
         this.recipientName = recipientName;
@@ -70,7 +69,5 @@ public class Letter {
         this.content = content;
         this.password = password;
         this.letterStatus = letterStatus;
-        this.createdDatetime = createdDatetime;
-        this.updatedDatetime = updatedDatetime;
     }
 }

--- a/src/main/java/com/snailmail/back/dto/request/LetterCreateRequest.java
+++ b/src/main/java/com/snailmail/back/dto/request/LetterCreateRequest.java
@@ -1,0 +1,34 @@
+package com.snailmail.back.dto.request;
+
+import com.snailmail.back.domain.Letter;
+import com.snailmail.back.domain.LetterStatus;
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LetterCreateRequest {
+
+    private String reservationKey;
+    private String senderName;
+    private String recipientName;
+    private String recipientEmail;
+    private Integer duration;
+    private String content;
+    private String password;
+
+    public Letter toEntity(LocalDate scheduledDate) {
+        return Letter.builder()
+                .reservationKey(reservationKey)
+                .senderName(senderName)
+                .recipientName(recipientName)
+                .recipientEmail(recipientEmail)
+                .duration(duration)
+                .scheduledDate(scheduledDate)
+                .content(content)
+                .password(password)
+                .letterStatus(LetterStatus.SCHEDULED)
+                .build();
+    }
+}

--- a/src/main/java/com/snailmail/back/dto/request/LetterCreateRequest.java
+++ b/src/main/java/com/snailmail/back/dto/request/LetterCreateRequest.java
@@ -10,7 +10,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class LetterCreateRequest {
 
-    private String reservationKey;
     private String senderName;
     private String recipientName;
     private String recipientEmail;
@@ -18,17 +17,22 @@ public class LetterCreateRequest {
     private String content;
     private String password;
 
-    public Letter toEntity(LocalDate scheduledDate) {
+    public Letter toEntity() {
         return Letter.builder()
-                .reservationKey(reservationKey)
                 .senderName(senderName)
                 .recipientName(recipientName)
                 .recipientEmail(recipientEmail)
                 .duration(duration)
-                .scheduledDate(scheduledDate)
+                .scheduledDate(getScheduledDate())
                 .content(content)
                 .password(password)
                 .letterStatus(LetterStatus.SCHEDULED)
                 .build();
+    }
+
+    private LocalDate getScheduledDate() {
+        LocalDate today = LocalDate.now();
+
+        return today.plusDays(duration);
     }
 }

--- a/src/main/java/com/snailmail/back/dto/response/ApiResponse.java
+++ b/src/main/java/com/snailmail/back/dto/response/ApiResponse.java
@@ -1,0 +1,22 @@
+package com.snailmail.back.dto.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ApiResponse<T> {
+
+    private String code;
+    private T data;
+    private String message;
+
+    protected ApiResponse(String code, T data) {
+        this.code = code;
+        this.data = data;
+    }
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>("success", data);
+    }
+}

--- a/src/main/java/com/snailmail/back/dto/response/LetterResponse.java
+++ b/src/main/java/com/snailmail/back/dto/response/LetterResponse.java
@@ -1,6 +1,7 @@
 package com.snailmail.back.dto.response;
 
 import com.snailmail.back.domain.Letter;
+import com.snailmail.back.domain.LetterStatus;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
@@ -22,6 +23,7 @@ public class LetterResponse {
     private Integer duration;
     private LocalDate scheduledDate;
     private String content;
+    private LetterStatus letterStatus;
     private LocalDateTime createdDatetime;
     private LocalDateTime updatedDatetime;
 
@@ -35,6 +37,7 @@ public class LetterResponse {
                 .duration(letter.getDuration())
                 .scheduledDate(letter.getScheduledDate())
                 .content(letter.getContent())
+                .letterStatus(letter.getLetterStatus())
                 .createdDatetime(letter.getCreatedDatetime())
                 .updatedDatetime(letter.getUpdatedDatetime())
                 .build();

--- a/src/main/java/com/snailmail/back/dto/response/LetterResponse.java
+++ b/src/main/java/com/snailmail/back/dto/response/LetterResponse.java
@@ -1,0 +1,42 @@
+package com.snailmail.back.dto.response;
+
+import com.snailmail.back.domain.Letter;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LetterResponse {
+
+    private Long id;
+    private String reservationKey;
+    private String senderName;
+    private String recipientName;
+    private String recipientEmail;
+    private Integer duration;
+    private LocalDate scheduledDate;
+    private String content;
+    private LocalDateTime createdDatetime;
+    private LocalDateTime updatedDatetime;
+
+    public static LetterResponse fromEntity(Letter letter) {
+        return LetterResponse.builder()
+                .id(letter.getId())
+                .reservationKey(letter.getReservationKey())
+                .senderName(letter.getSenderName())
+                .recipientName(letter.getRecipientName())
+                .recipientEmail(letter.getRecipientEmail())
+                .duration(letter.getDuration())
+                .scheduledDate(letter.getScheduledDate())
+                .content(letter.getContent())
+                .createdDatetime(letter.getCreatedDatetime())
+                .updatedDatetime(letter.getUpdatedDatetime())
+                .build();
+    }
+}

--- a/src/main/java/com/snailmail/back/service/LetterService.java
+++ b/src/main/java/com/snailmail/back/service/LetterService.java
@@ -4,7 +4,6 @@ import com.snailmail.back.domain.Letter;
 import com.snailmail.back.dto.request.LetterCreateRequest;
 import com.snailmail.back.dto.response.LetterResponse;
 import com.snailmail.back.repository.LetterRepository;
-import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,12 +16,9 @@ public class LetterService {
 
     @Transactional
     public LetterResponse createLetter(LetterCreateRequest request) {
-        LocalDate today = LocalDate.now();
-        LocalDate scheduledDate = today.plusDays(request.getDuration());
+        Letter savedLetter = letterRepository.save(request.toEntity());
+        savedLetter.registerReservationKey();
 
-        Letter letter = request.toEntity(scheduledDate);
-        letterRepository.save(letter);
-
-        return LetterResponse.fromEntity(letter);
+        return LetterResponse.fromEntity(savedLetter);
     }
 }

--- a/src/main/java/com/snailmail/back/service/LetterService.java
+++ b/src/main/java/com/snailmail/back/service/LetterService.java
@@ -1,0 +1,28 @@
+package com.snailmail.back.service;
+
+import com.snailmail.back.domain.Letter;
+import com.snailmail.back.dto.request.LetterCreateRequest;
+import com.snailmail.back.dto.response.LetterResponse;
+import com.snailmail.back.repository.LetterRepository;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class LetterService {
+
+    private final LetterRepository letterRepository;
+
+    @Transactional
+    public LetterResponse createLetter(LetterCreateRequest request) {
+        LocalDate today = LocalDate.now();
+        LocalDate scheduledDate = today.plusDays(request.getDuration());
+
+        Letter letter = request.toEntity(scheduledDate);
+        letterRepository.save(letter);
+
+        return LetterResponse.fromEntity(letter);
+    }
+}

--- a/src/main/java/com/snailmail/back/utils/StringUtil.java
+++ b/src/main/java/com/snailmail/back/utils/StringUtil.java
@@ -1,0 +1,38 @@
+package com.snailmail.back.utils;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+public final class StringUtil {
+
+    private static final String DATE_SPLIT_REGEX = "-";
+
+    private static final String ZERO_FILL_FORMAT = "%04d";
+
+    private static final Integer FIRST_UPPER_ALPHABET_ASCII = 65;
+    private static final Integer LAST_UPPER_ALPHABET_ASCII = 91;
+    private static final Integer RANDOM_STRING_SIZE = 5;
+
+    public static String localDateToString(LocalDate localDate) {
+        String[] localDateStrings = localDate.toString().split(DATE_SPLIT_REGEX);
+
+        return Arrays.stream(localDateStrings)
+                .collect(Collectors.joining());
+    }
+
+    public static String fillZero(Long target) {
+        return String.format(ZERO_FILL_FORMAT, target);
+    }
+
+    public static String getRandomUppercaseString() {
+        Random random = new Random();
+
+        return random.ints(FIRST_UPPER_ALPHABET_ASCII, LAST_UPPER_ALPHABET_ASCII)
+                .limit(RANDOM_STRING_SIZE)
+                .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+                .toString();
+    }
+
+}

--- a/src/test/java/com/snailmail/back/domain/LetterTest.java
+++ b/src/test/java/com/snailmail/back/domain/LetterTest.java
@@ -20,7 +20,7 @@ class LetterTest {
     }
 
     @Test
-    @DisplayName("편지 객체 정상 생성 여부 확인")
+    @DisplayName("편지 객체가 정상적으로 생성되는지 확인한다.")
     void saveLetterTest() {
         // given
         Letter letter = Letter.builder()

--- a/src/test/java/com/snailmail/back/domain/LetterTest.java
+++ b/src/test/java/com/snailmail/back/domain/LetterTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.snailmail.back.repository.LetterRepository;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,8 +33,6 @@ class LetterTest {
                 .content("test content")
                 .password("kyle1234")
                 .letterStatus(LetterStatus.SCHEDULED)
-                .createdDatetime(LocalDateTime.now())
-                .updatedDatetime(LocalDateTime.now())
                 .build();
 
         // when

--- a/src/test/java/com/snailmail/back/utils/StringUtilTest.java
+++ b/src/test/java/com/snailmail/back/utils/StringUtilTest.java
@@ -1,0 +1,30 @@
+package com.snailmail.back.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class StringUtilTest {
+
+    @ParameterizedTest
+    @DisplayName("날짜 데이터를 넣었을 때, 년월일 숫자만 문자열로 파싱하는지 확인한다.")
+    @CsvSource({"2023-07-12,20230712", "2014-05-12,20140512", "2020-09-13,20200913"})
+    void localDateToStringTest(String input, String expected) {
+        LocalDate localDate = LocalDate.parse(input);
+        String actual = StringUtil.localDateToString(localDate);
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @DisplayName("정수를 넣었을 때, 비어있는 부분만큼 0을 채워서 4자리 문자열로 반환하는지 확인한다.")
+    @CsvSource({"1,0001", "20,0020", "234,0234", "1234,1234"})
+    void fillZeroTest(Long input, String expected) {
+        String actual = StringUtil.fillZero(input);
+
+        assertThat(actual).isEqualTo(expected);
+    }
+}


### PR DESCRIPTION
### [[B002] 새로운 편지 생성 기능](https://www.notion.so/B002-87bd5925b142446c80644167a865b2ea?pvs=4)
- `POST /api/letters`
- Reservation Key 자동 생성 기능 추가
  - `{생성날짜}{ID}{랜덤문자열5개}` 형식 (ex. "202307300003PTFUS")
- StringUtil 클래스에 대한 테스트 코드 추가
- 아래는 응답 예시입니다.
```json
{
    "code": "success",
    "data": {
        "id": 3,
        "reservationKey": "202307300003PTFUS",
        "senderName": "kyle",
        "recipientName": "alex",
        "recipientEmail": "kyle@gmail.com",
        "duration": 364,
        "scheduledDate": "2024-07-28",
        "content": "크리스마스의 나에게 보내는 편지...(생략)",
        "createdDatetime": "2023-07-30T17:30:38.773014",
        "updatedDatetime": "2023-07-30T17:30:38.773014"
    },
    "message": null
}
```

---

추후 작업 예정
- Service 로직 테스트 코드 (with Mockito)
- 나머지 편지 기능 (READ, UPDATE, DELETE)